### PR TITLE
Switch to using prefix magic bytes to identify compression types

### DIFF
--- a/magic.go
+++ b/magic.go
@@ -1,0 +1,31 @@
+package zreader
+
+import "bytes"
+
+const magicBytePrefixSize = 4
+
+var (
+	magicBzip2             = []byte{0x42, 0x5a, 0x68}
+	magicGzip              = []byte{0x1f, 0x8b}
+	magicZip               = []byte{0x50, 0x4b, 0x03, 0x04}
+	magicZipEmptyArchive   = []byte{0x50, 0x4b, 0x05, 0x06}
+	magicZipSpannedArchive = []byte{0x50, 0x4b, 0x07, 0x08}
+	magicZstd              = []byte{0x28, 0xb5, 0x2f, 0xfd}
+)
+
+func zTypeFromBytes(magic []byte) zType {
+	switch {
+	case bytes.HasPrefix(magic, magicBzip2):
+		return zBzip2
+	case bytes.HasPrefix(magic, magicGzip):
+		return zGzip
+	case bytes.HasPrefix(magic, magicZip),
+		bytes.HasPrefix(magic, magicZipEmptyArchive),
+		bytes.HasPrefix(magic, magicZipSpannedArchive):
+		return zZip
+	case bytes.HasPrefix(magic, magicZstd):
+		return zZstd
+	default:
+		return zNone
+	}
+}

--- a/zreader.go
+++ b/zreader.go
@@ -38,6 +38,8 @@ type ZReader struct {
 	zType
 
 	decompressor io.ReadCloser
+
+	fileCloser io.Closer
 }
 
 // Open opens pathname and returns an appropriate ZReader. See [NewReader] for
@@ -56,6 +58,7 @@ func Open(pathname string) (*ZReader, error) {
 
 		return nil, err
 	}
+	zr.fileCloser = file
 
 	return zr, nil
 }
@@ -105,5 +108,13 @@ func (z *ZReader) Read(p []byte) (int, error) {
 
 // Close closes the ZReader, will close the underlying reader if it has one.
 func (z *ZReader) Close(p []byte) error {
-	return z.decompressor.Close()
+	if err := z.decompressor.Close(); err != nil {
+		return err
+	}
+
+	if z.fileCloser != nil {
+		return z.fileCloser.Close()
+	}
+
+	return nil
 }

--- a/zreader.go
+++ b/zreader.go
@@ -6,12 +6,11 @@
 package zreader
 
 import (
+	"bufio"
 	"compress/bzip2"
 	"compress/gzip"
 	"io"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -36,82 +35,75 @@ const (
 //
 // It currently supports bzip2, gzip, and zstd.
 type ZReader struct {
-	file *os.File
 	zType
-	bzip2Reader io.Reader
-	gzipReader  *gzip.Reader
-	zstdDecoder *zstd.Decoder
+
+	decompressor io.ReadCloser
 }
 
-// Open opens pathname and returns an appropriate ZReader. It selects a
-// decompressor based on pathname's file extension. If it does not have a
-// decompressor to match the extension, subsequent calls to [Read] will return
-// the raw bytes of the file. (That might, or might not, be what you want.)
+// Open opens pathname and returns an appropriate ZReader. See [NewReader] for
+// guidance on its behavior.
 func Open(pathname string) (*ZReader, error) {
 	file, e := os.Open(pathname)
 	if e != nil {
 		return nil, e
 	}
 
-	reader := &ZReader{file: file}
+	zr, err := NewReader(file)
+	if err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, closeErr
+		}
 
-	fileType := strings.ToLower(filepath.Ext(pathname))
-	switch fileType {
-	case ".bz2":
-		reader.zType = zBzip2
-		reader.bzip2Reader = bzip2.NewReader(reader.file)
-	case ".gz":
-		reader.zType = zGzip
-		r, e := gzip.NewReader(reader.file)
+		return nil, err
+	}
+
+	return zr, nil
+}
+
+// NewReader returns a ZReader for the given io.ReadCloser. It selects a
+// decompressor based on the first few bytes of data. If it does not have a
+// decompressor to match the bytes, subsequent calls to [Read] will return the
+// raw bytes of the reader. (That might, or might not, be what you want.)
+func NewReader(r io.Reader) (*ZReader, error) {
+	return fromBufferedReader(bufio.NewReader(r))
+}
+
+func fromBufferedReader(uncompressed *bufio.Reader) (*ZReader, error) {
+	magicBlock, err := uncompressed.Peek(magicBytePrefixSize)
+	if err != nil {
+		return nil, err
+	}
+
+	switch zTypeFromBytes(magicBlock) {
+	case zBzip2:
+		return &ZReader{zType: zBzip2, decompressor: io.NopCloser(bzip2.NewReader(uncompressed))}, nil
+	case zGzip:
+		r, e := gzip.NewReader(uncompressed)
 		if e != nil {
-			reader.file.Close()
 			return nil, e
 		}
-		reader.gzipReader = r
-	case ".zip":
-		reader.zType = zZip
+
+		return &ZReader{zType: zGzip, decompressor: r}, nil
+	case zZip:
 		// TODO
-	case ".zstd":
-		reader.zType = zZstd
-		d, e := zstd.NewReader(reader.file)
+		return &ZReader{zType: zZip, decompressor: io.NopCloser(uncompressed)}, nil
+	case zZstd:
+		d, e := zstd.NewReader(uncompressed)
 		if e != nil {
-			reader.file.Close()
 			return nil, e
 		}
-		reader.zstdDecoder = d
+		return &ZReader{zType: zZstd, decompressor: io.NopCloser(d)}, nil
 	default:
-		reader.zType = zNone
+		return &ZReader{zType: zNone, decompressor: io.NopCloser(uncompressed)}, nil
 	}
-	return reader, nil
 }
 
-// Read reads up to len(bytes) from the File and stores them in bytes. It
-// returns the number of bytes read and any error encountered. At end of file,
-// Read returns 0, io.EOF.
-func (zr *ZReader) Read(bytes []byte) (n int, err error) {
-	switch zr.zType {
-	case zBzip2:
-		return zr.bzip2Reader.Read(bytes)
-	case zGzip:
-		return zr.gzipReader.Read(bytes)
-	case zZip:
-		// TODO
-	case zZstd:
-		return zr.zstdDecoder.Read(bytes)
-	}
-	return zr.file.Read(bytes)
+// Read reads from the appropriate decompressor.
+func (z *ZReader) Read(p []byte) (int, error) {
+	return z.decompressor.Read(p)
 }
 
-// Close closes zr, rendering it unusable for I/O. Close will return an error if
-// it has already been called.
-func (zr *ZReader) Close() error {
-	switch zr.zType {
-	case zNone:
-	case zBzip2:
-	case zGzip:
-		zr.gzipReader.Close()
-	case zZip:
-	case zZstd:
-	}
-	return zr.file.Close()
+// Close closes the ZReader, will close the underlying reader if it has one.
+func (z *ZReader) Close(p []byte) error {
+	return z.decompressor.Close()
 }

--- a/zreader_test.go
+++ b/zreader_test.go
@@ -20,16 +20,18 @@ func TestZReader(t *testing.T) {
 		"test-data/zreader.txt.gz",
 	}
 	for _, zf := range zfiles {
-		reader, e := Open(zf)
-		if e != nil {
-			t.Error(e)
-		}
-		bytes, e := io.ReadAll(reader)
-		if e != nil {
-			t.Error(e)
-		}
-		if !slices.Equal(expected, bytes) {
-			t.Errorf("%q was wrong!", zf)
-		}
+		t.Run(zf, func(t *testing.T) {
+			reader, e := Open(zf)
+			if e != nil {
+				t.Error(e)
+			}
+			bytes, e := io.ReadAll(reader)
+			if e != nil {
+				t.Error(e)
+			}
+			if !slices.Equal(expected, bytes) {
+				t.Errorf("%q was wrong!", zf)
+			}
+		})
 	}
 }

--- a/zreader_test.go
+++ b/zreader_test.go
@@ -16,6 +16,7 @@ func TestZReader(t *testing.T) {
 		t.Error(e)
 	}
 	zfiles := []string{
+		"test-data/zreader.txt",
 		"test-data/zreader.txt.bz2",
 		"test-data/zreader.txt.gz",
 	}


### PR DESCRIPTION
* Switch to using magic bytes for stream identification
* Add unknown bytes test case
* Label tests so its slightly easier to debug failures